### PR TITLE
feature: Add option to display an application's title

### DIFF
--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -214,6 +214,11 @@ void bar_manager_set_position(struct bar_manager *bar_manager, char *pos)
   bar_manager_resize(bar_manager);
 }
 
+void bar_manager_set_title(struct bar_manager *bar_manager, bool value)
+{
+  bar_manager->title = value;
+}
+
 void bar_manager_set_height(struct bar_manager *bar_manager, uint32_t height)
 {
   bar_manager->height = height;

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -33,6 +33,7 @@ struct bar_manager
   struct bar_line battr_icon;
   struct bar_line power_icon;
   struct bar_line dnd_icon;
+  bool title;
 };
 
 void bar_manager_set_foreground_color(struct bar_manager *bar_manager, uint32_t color);
@@ -51,6 +52,7 @@ void bar_manager_set_clock_format(struct bar_manager *bar_manager, char *format)
 void bar_manager_set_space_icon(struct bar_manager *bar_manager, char *icon);
 void bar_manager_set_dnd_icon(struct bar_manager *bar_manager, char *icon);
 void bar_manager_set_position(struct bar_manager *bar_manager, char *pos);
+void bar_manager_set_title(struct bar_manager *bar_manager, bool value);
 void bar_manager_set_height(struct bar_manager *bar_manager, uint32_t height);
 void bar_manager_set_spacing_left(struct bar_manager *bar_manager, uint32_t spacing);
 void bar_manager_set_spacing_right(struct bar_manager *bar_manager, uint32_t spacing);

--- a/src/message.c
+++ b/src/message.c
@@ -31,6 +31,7 @@ extern bool g_verbose;
 #define COMMAND_CONFIG_BAR_HEIGHT              "height"
 #define COMMAND_CONFIG_BAR_SPACING_LEFT        "spacing_left"
 #define COMMAND_CONFIG_BAR_SPACING_RIGHT       "spacing_right"
+#define COMMAND_CONFIG_BAR_TITLE               "title"
 
 /* --------------------------------COMMON ARGUMENTS----------------------------- */
 #define ARGUMENT_COMMON_VAL_ON     "on"
@@ -303,6 +304,16 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
 	fprintf(rsp, "%"PRIu32"\n", g_bar_manager.spacing_right ? g_bar_manager.spacing_right : 0);
       } else {
 	bar_manager_set_spacing_right(&g_bar_manager, atoi(token_to_string(token)));
+      }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_TITLE)) {
+      char * on = "on";
+      char * off = "off";
+      if (strcmp(message,on) == 0) {
+        bar_manager_set_title(&g_bar_manager, true);
+      } else if (strcmp(message,off) == 0) {
+        bar_manager_set_title(&g_bar_manager, false);
+      } else {
+        daemon_fail(rsp, "value for '%.*s' must be either 'on' or 'off'.\n", command.length, command.text);
       }
     } else {
       daemon_fail(rsp, "unknown command '%.*s' for domain '%.*s'\n", command.length, command.text, domain.length, domain.text);


### PR DESCRIPTION
The option can be used as `spacebar -m config title <on|off>`, and determines whether or not to display an application's title. By default, the title won't be displayed (I couldn't figure out how to implement displaying the title if a config value wasn't provided).

Although this works for me, I must ask if it would be possible for someone with experience in C go over the changes and make sure that I didn't mess up anything as I'm not that experienced in C.