### PR TITLE
Add/fix "get space_icon_strip"

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -168,11 +168,20 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
     } else if (token_equals(command, COMMAND_CONFIG_BAR_SPACE_STRIP)) {
         char **icon_strip = NULL;
         struct token token = get_token(&message);
-        while (token.text && token.length > 0) {
-            buf_push(icon_strip, token_to_string(token));
-            token = get_token(&message);
+
+        if(token.length==0){ // If no value given, print current value
+            fprintf(rsp, "\"%s\"", *g_bar_manager._space_icon_strip);
+            char **p = g_bar_manager._space_icon_strip;
+            for(int i = 1; i<buf_len(g_bar_manager.space_icon_strip);i++) {
+                fprintf(rsp, " \"%s\"", *++p);
+            }
+        } else { // Else, set value
+            while (token.text && token.length > 0) {
+                buf_push(icon_strip, token_to_string(token));
+                token = get_token(&message);
+            }
+            bar_manager_set_space_strip(&g_bar_manager, icon_strip);
         }
-        bar_manager_set_space_strip(&g_bar_manager, icon_strip);
     } else if (token_equals(command, COMMAND_CONFIG_BAR_POWER_STRIP)) {
         char **icon_strip = NULL;
         struct token token = get_token(&message);


### PR DESCRIPTION
**DISCLAIMER:** I have no experience with C, and I do not know what I am doing.
 
I wanted to write a script that manages spaces and space names with yabai and spacebar. And to do that, I wanted to get the current space_icon_strip from spacebar. But as described in #35, I could not get it to work as I expected.

If no value given when calling `spacebar -m config space_icon_strip`,
print the current value.

It prints icon strip names delimited by spaces and surrounded with double
quotation marks, so it supports space names with spaces.

I did not really expect to able to solve it myself, but I cloned the repository and poked around a bit and got it to work like I expected. So this fixes #35 for me.

But do not have high confidence in what the code does. I do not know if it adheres to any style guide or conventions. So I am very open for suggestions for how to improve it.
