### PR TITLE
Fix Font Awesome font variant in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ spacebar -m config height             26
 spacebar -m config spacing_left       25
 spacebar -m config spacing_right      15
 spacebar -m config text_font          "Helvetica Neue:Bold:12.0"
-spacebar -m config icon_font          "Font Awesome 5 Free:Regular:12.0"
+spacebar -m config icon_font          "Font Awesome 5 Free:Solid:12.0"
 spacebar -m config background_color   0xff202020
 spacebar -m config foreground_color   0xffa8a8a8
 spacebar -m config space_icon_color   0xff458588


### PR DESCRIPTION
In the README, the font specified for Font Awesome uses `Regular` which results in icons not being rendered, whereas it should be `Solid`